### PR TITLE
remove default namespace

### DIFF
--- a/kubernetes/03_ingress.yaml
+++ b/kubernetes/03_ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: chuck
-  namespace: default
   annotations:
     # this important https://docs.konghq.com/kubernetes-ingress-controller/1.3.x/references/annotations/#konghqcomstrip-path
     konghq.com/strip-path: "true"


### PR DESCRIPTION
I removed the namespace: default   like that we can deploy ingress into other namespace